### PR TITLE
Fix links

### DIFF
--- a/components/cabins/CabinPeek.js
+++ b/components/cabins/CabinPeek.js
@@ -20,7 +20,7 @@ export default function CabinPeek({ name, slug, summary, image, imageAlt }) {
         </div>
         <div>
           <p>{summary}</p>
-          <ArrowLink href={`/cabins/${slug}`} color="forest" label="Learn more" />
+          <ArrowLink href={`/visit/${slug}`} color="forest" label="Learn more" />
         </div>
       </CabinContent>
     </Cabin>

--- a/components/home/Node.js
+++ b/components/home/Node.js
@@ -21,7 +21,7 @@ export default function Node() {
           <div>
             <h2>Node 1</h2>
             <h3>Creator cabins in Texas Hill Country</h3>
-            <ArrowLink href="/cabins" label="Explore the cabins" />
+            <ArrowLink href="/visit" label="Explore the cabins" />
           </div>
           <div>
             <p>

--- a/pages/visit/thecabin/index.js
+++ b/pages/visit/thecabin/index.js
@@ -11,7 +11,7 @@ export default function TheCabin() {
   const { amenities, gallery, ...others } = theCabin;
   return (
     <Layout>
-      <BackLink label="Texas Hill Country" href="/cabins" />
+      <BackLink label="Texas Hill Country" href="/visit" />
       <CabinIntro { ...others } />
       <Gallery images={ gallery } />
       <Amenities list={amenities} />

--- a/pages/visit/thecontainer/index.js
+++ b/pages/visit/thecontainer/index.js
@@ -11,7 +11,7 @@ export default function TheContainer() {
   const { amenities, gallery, ...others } = theContainer;
   return (
     <Layout>
-      <BackLink label="Texas Hill Country" href="/cabins" />
+      <BackLink label="Texas Hill Country" href="/visit" />
       <CabinIntro { ...others } />
       <Gallery images={ gallery } />
       <Amenities list={amenities} />


### PR DESCRIPTION
Links had been broken when the 'cabins' section of the site was changed to 'visit'.  This updates those links so they are functional again.