### PR TITLE
Fix discord invite

### DIFF
--- a/components/home/Collaborate.js
+++ b/components/home/Collaborate.js
@@ -25,7 +25,7 @@ export default function Collaborate() {
             We believe in the power of bringing people together IRL, especially for decentralized and distributed teams. While the vast majority of a DAO&apos;s work should be accomplished via asynchronous, remote, distributed work, there is tremendous leverage in getting together face-to-face for strategic thinking, team bonding, and deep collaboration. Cabin is the DAO to help other DAOs accelerate their work by getting together IRL.
           </p>
           <Actions>
-            <ButtonLink external target="_blank" href="https://discord.com/invite/N6hVmFygjR" label="Join the community" />
+            <ButtonLink external target="_blank" href="https://discord.gg/ttgRU7QKVE" label="Join the community" />
           </Actions>
         </Content>
       </Wrapper>


### PR DESCRIPTION
Replacing another (last) Discord invite link with one that won't expire